### PR TITLE
chore: Run tests and build before publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "module": "dist/eventhub.mjs",
   "unpkg": "dist/eventhub.umd.js",
   "scripts": {
+    "prepublishOnly": "npm run test && npm run build",
     "build": "microbundle --name Eventhub",
     "test": "jest",
     "test-dev": "jest --watch --verbose false",


### PR DESCRIPTION
> prepublishOnly: Run BEFORE the package is prepared and packed, ONLY on npm publish.