### PR TITLE
Fix: unsub callback

### DIFF
--- a/src/eventhub.ts
+++ b/src/eventhub.ts
@@ -146,6 +146,10 @@ export default class Eventhub extends EventEmitter implements IEventhub {
     });
   }
 
+  get isConnected() {
+      return this._isConnected;
+  }
+
   /*
    * Try to reconnect in a loop until we succeed.
   */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "module": "es2015"
+    "module": "es2015",
+    "target": "es5"
   },
   "files": [
     "src/eventhub.ts"


### PR DESCRIPTION
closes #25 

TODO: tests

`Set` is not available in <ES6 environments, would have to replace it with something else if we want to keep supporting that. People usually transpile/bundle/polyfill dependencies as well as sources, so maybe we could bump target to ES6+? (would be a breaking change ofc)