### PR TITLE
fix: Adjust events type and use shorthand for ConnectionOptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "eventhub-jsclient",
-      "version": "2.1.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@types/ws": "^8.5.2",

--- a/src/eventhub.ts
+++ b/src/eventhub.ts
@@ -45,6 +45,13 @@ const enum LifecycleEvents {
   OFFLINE = 'offline',
 }
 
+type MittEvents = {
+  connect: void;
+  reconnect: void;
+  disconnect: void;
+  offline: ErrorEvent | CloseEvent;
+};
+
 interface Subscription {
   topic: string;
   rpcRequestId: number;
@@ -96,13 +103,6 @@ interface EventlogResult {
 
 declare interface IEventhub {}
 
-type MittEvents = {
-  [LifecycleEvents.CONNECT]: void;
-  [LifecycleEvents.OFFLINE]: ErrorEvent | CloseEvent;
-  [LifecycleEvents.RECONNECT]: void;
-  [LifecycleEvents.DISCONNECT]: void;
-};
-
 class Eventhub implements IEventhub {
   private _wsUrl: string;
   private _socket: WebSocket;
@@ -125,7 +125,7 @@ class Eventhub implements IEventhub {
    * @param token Authentication token.
    * @param opts Options.
    */
-  constructor(url: string, token?: string, opts?: { [P in keyof ConnectionOptions]?: ConnectionOptions[P] }) {
+  constructor(url: string, token?: string, opts?: Partial<ConnectionOptions>) {
     this._wsUrl = `${url}/?auth=${token}`;
     this._opts = new ConnectionOptions();
     this._emitter = mitt(); // event emitter


### PR DESCRIPTION
**Summary**

It seems that TS doesn't accept strings matching an enum prop, like it's used here:

```ts
const enum LifecycleEvents {
    CONNECT = "connect",
    RECONNECT = "reconnect",
    DISCONNECT = "disconnect",
    OFFLINE = "offline"
}
type MittEvents = {
    [LifecycleEvents.CONNECT]: void;
    [LifecycleEvents.OFFLINE]: ErrorEvent | CloseEvent;
    [LifecycleEvents.RECONNECT]: void;
    [LifecycleEvents.DISCONNECT]: void;
};

//  TS ERROR: Type '"connect"' is not assignable to type 'LifecycleEvents'.
const eventName: keyof MittEvents = 'connect';
```

It was used in `.on` and `.off`

Additionally, I updated `{ [P in keyof ConnectionOptions]: P?: ConnectionOptions[P] }` to use shorthand `Partial<ConnectionOptions>`