### PR TITLE
feat: export `Eventhub` as named export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "eventhub-jsclient",
-      "version": "2.1.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@types/ws": "^8.5.2",

--- a/src/eventhub.ts
+++ b/src/eventhub.ts
@@ -103,7 +103,7 @@ type MittEvents = {
   [LifecycleEvents.DISCONNECT]: void;
 };
 
-class Eventhub implements IEventhub {
+export class Eventhub implements IEventhub {
   private _wsUrl: string;
   private _socket: WebSocket;
   private _opts: ConnectionOptions = new ConnectionOptions();


### PR DESCRIPTION
# Why

Because TS throws an error when trying to use it in EcmaScript modules project
`TS2709: Cannot use namespace Eventhub as a type`
![image](https://github.com/user-attachments/assets/7629bfaf-562a-4b42-8674-57173819b2b6)


allowing named import fixes all problems
```ts
import { Eventhub } from 'eventhub-jsclient';
```

# What

[feat: export Eventhub as named export](https://github.com/olesku/eventhub-jsclient/commit/375a378d41e14b4139466c5ccce7ea4c0ed200f0) 

- because default export is interpreted wrongly by TypeScript in ESM environment while named export works smoothly
- named export is also nicer for autocompletion